### PR TITLE
Revert "Fix font path configuration for Typst mathematical SVG rendering"

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -48,7 +48,7 @@ export default defineConfig({
         detect: () => "html",
       },
       options: {
-        fontArgs: [{ fontPaths: ["./assets/fonts", "./public/fonts"] }],
+        fontArgs: [{ fontPaths: ["./assets/fonts/", "./public/fonts"] }],
       },
     }),
   ],


### PR DESCRIPTION
Reverts pxwg/blog#1